### PR TITLE
Store leaves on tree, copy to clipboard

### DIFF
--- a/deciduous.js
+++ b/deciduous.js
@@ -1,1 +1,0 @@
-console.log("running a regular JS file")

--- a/popup/text_zone.css
+++ b/popup/text_zone.css
@@ -1,0 +1,4 @@
+.button-wrapper {
+  display: flex;
+  justify-content: space-between;
+}

--- a/popup/text_zone.html
+++ b/popup/text_zone.html
@@ -9,8 +9,8 @@
     <textarea name="deciduous_text_zone" id="deciduous_text_zone" cols="30" rows="10"></textarea>
     
     <div class="button-wrapper">
-      <button>🍃</button>
-      <button>📎</button>
+      <button id="leaf-button">🍃</button>
+      <button id="copy-button" >📎</button>
     </div>
     
     <script src="text_zone.js"></script>

--- a/popup/text_zone.js
+++ b/popup/text_zone.js
@@ -1,1 +1,63 @@
-console.log("Clicked the text zone")
+const textArea = document.querySelector("#deciduous_text_zone");
+
+const leafButton = document.querySelector("#leaf-button");
+const copyButton = document.querySelector("#copy-button");
+
+leafButton.addEventListener("click", appendLeaf);
+copyButton.addEventListener("click", copyTreeToClipboard);
+
+function appendLeaf() {
+  const leafText = textArea.value;
+  const currentTreePromise = browser.storage.local.get("deciduousTree");
+
+  currentTreePromise.then((result) => {
+    // what happens if this is empty to begin with??
+
+    const tree = result[0].deciduousTree
+
+    // check that we can read the current value of the tree
+    console.log(`current tree: ${tree}`)
+    
+    setToStorage(tree, leafText);
+    leafText.value = "";
+  }, onError);
+}
+
+function setToStorage(currentTree, text) {
+  // is there a more elegant way to append?
+  const storingLeaf = browser.storage.local.set({"deciduousTree": `${currentTree} \n \n ${text}`});
+
+  // check that we're correctly appending the current text to the tree
+  console.log(`storing this: ${currentTree} \n \n ${text}`)
+
+  storingLeaf.then(() => {
+    window.close();
+  }, onError)
+}
+
+function copyTreeToClipboard() {
+  const currentTreePromise = browser.storage.local.get("deciduousTree");
+
+  currentTreePromise.then((result) => {
+    const tree = result[0].deciduousTree
+
+    writeToClipboard(tree);
+    clearStorage();
+  })
+}
+
+function writeToClipboard(content) {
+  navigator.clipboard.writeText(content).then(() => {
+    window.close();
+  }, onError)
+}
+
+function clearStorage() {
+  browser.storage.local.clear().then(() => {
+    console.log("cleared storage");
+  }, isError);
+}
+
+function onError(error) {
+  console.log(error);
+}

--- a/popup/text_zone.js
+++ b/popup/text_zone.js
@@ -9,26 +9,22 @@ copyButton.addEventListener("click", copyTreeToClipboard);
 function appendLeaf() {
   const leafText = textArea.value;
   const currentTreePromise = browser.storage.local.get("deciduousTree");
-
+  
   currentTreePromise.then((result) => {
-    // what happens if this is empty to begin with??
+    const tree = result.deciduousTree
 
-    const tree = result[0].deciduousTree
+    if(tree) {
+      setToStorage(tree, leafText);
+    } else {
+      setToStorage("", leafText)
+    }
 
-    // check that we can read the current value of the tree
-    console.log(`current tree: ${tree}`)
-    
-    setToStorage(tree, leafText);
     leafText.value = "";
   }, onError);
 }
 
 function setToStorage(currentTree, text) {
-  // is there a more elegant way to append?
   const storingLeaf = browser.storage.local.set({"deciduousTree": `${currentTree} \n \n ${text}`});
-
-  // check that we're correctly appending the current text to the tree
-  console.log(`storing this: ${currentTree} \n \n ${text}`)
 
   storingLeaf.then(() => {
     window.close();
@@ -39,7 +35,7 @@ function copyTreeToClipboard() {
   const currentTreePromise = browser.storage.local.get("deciduousTree");
 
   currentTreePromise.then((result) => {
-    const tree = result[0].deciduousTree
+    const tree = result.deciduousTree
 
     writeToClipboard(tree);
     clearStorage();
@@ -55,7 +51,7 @@ function writeToClipboard(content) {
 function clearStorage() {
   browser.storage.local.clear().then(() => {
     console.log("cleared storage");
-  }, isError);
+  }, onError);
 }
 
 function onError(error) {


### PR DESCRIPTION
This contains the bulk of this project's initial functionality. It:

- Appends leaves (notes) on tree (storage document) with browser.storage.local
- Writes the contents of the tree to the clipboard for pasting in a more permanent store.
- Resets storage after copied to the clipboard.